### PR TITLE
Bpm compensation

### DIFF
--- a/qua3osu/Osu/BeatmapSections/TimingPointsSection.cs
+++ b/qua3osu/Osu/BeatmapSections/TimingPointsSection.cs
@@ -84,7 +84,7 @@ namespace qua3osu.Osu.BeatmapSections
 
                 if (!hasOutputTimingPoint || !NearlyEqual(currentOutputBpm, targetBpm))
                 {
-                    output.Add(TimingPoint.TimingChange(time, targetBpm));
+                    output.Add(TimingPoint.TimingChange(time, targetBpm, true));
                     currentOutputBpm = targetBpm;
                     hasOutputTimingPoint = true;
                 }

--- a/qua3osu/Osu/BeatmapSections/TimingPointsSection.cs
+++ b/qua3osu/Osu/BeatmapSections/TimingPointsSection.cs
@@ -5,6 +5,10 @@ namespace qua3osu.Osu.BeatmapSections
 {
     public class TimingPointsSection : BeatmapSection
     {
+        private const float MinOsuSliderVelocity = 0.01f;
+        private const float MaxOsuSliderVelocity = 10f;
+        private const double FloatTolerance = 0.000001;
+
         public List<TimingPoint> TimingPoints;
 
         public TimingPointsSection(Qua qua)
@@ -16,11 +20,7 @@ namespace qua3osu.Osu.BeatmapSections
                 qua.DenormalizeSVs();
             }
 
-            TimingPoints = qua.TimingPoints
-                .Select(timingPoint => new TimingPoint(timingPoint))
-                .Concat(qua.SliderVelocities.Select(sv => new TimingPoint(sv)))
-                .OrderBy(x => x.Time)
-                .ToList();
+            TimingPoints = BuildTimingPoints(qua);
         }
 
         protected override string SectionTitle => "TimingPoints";
@@ -32,5 +32,83 @@ namespace qua3osu.Osu.BeatmapSections
             TimingPoints.ForEach(tp => lines.AppendLine(tp.ToString()));
             return lines.ToString();
         }
+
+        private static List<TimingPoint> BuildTimingPoints(Qua qua)
+        {
+            var timingPoints = qua.TimingPoints.OrderBy(x => x.StartTime).ToList();
+            var sliderVelocities = qua.SliderVelocities.OrderBy(x => x.StartTime).ToList();
+
+            if (timingPoints.Count == 0)
+                return sliderVelocities.Select(sv => new TimingPoint(sv)).ToList();
+
+            var output = new List<TimingPoint>();
+            var timingPointIndex = 0;
+            var sliderVelocityIndex = 0;
+
+            var currentBpm = timingPoints[0].Bpm;
+            var currentOutputBpm = (double) currentBpm;
+            var currentSliderVelocity = 1f;
+            var hasSliderVelocity = false;
+            var hasOutputTimingPoint = false;
+
+            while (timingPointIndex < timingPoints.Count || sliderVelocityIndex < sliderVelocities.Count)
+            {
+                var nextTimingPointTime = timingPointIndex < timingPoints.Count
+                    ? timingPoints[timingPointIndex].StartTime
+                    : float.PositiveInfinity;
+                var nextSliderVelocityTime = sliderVelocityIndex < sliderVelocities.Count
+                    ? sliderVelocities[sliderVelocityIndex].StartTime
+                    : float.PositiveInfinity;
+                var time = Math.Min(nextTimingPointTime, nextSliderVelocityTime);
+
+                while (timingPointIndex < timingPoints.Count && timingPoints[timingPointIndex].StartTime == time)
+                {
+                    var timingPoint = timingPoints[timingPointIndex++];
+                    currentBpm = timingPoint.Bpm;
+                    currentOutputBpm = currentBpm;
+                    output.Add(new TimingPoint(timingPoint));
+                    hasOutputTimingPoint = true;
+                }
+
+                while (sliderVelocityIndex < sliderVelocities.Count && sliderVelocities[sliderVelocityIndex].StartTime == time)
+                {
+                    var sliderVelocity = sliderVelocities[sliderVelocityIndex++];
+                    currentSliderVelocity = sliderVelocity.Multiplier;
+                    hasSliderVelocity = true;
+                }
+
+                if (!hasSliderVelocity)
+                    continue;
+
+                var (targetBpm, targetSliderVelocity) = GetOutputTiming(currentBpm, currentSliderVelocity);
+
+                if (!hasOutputTimingPoint || !NearlyEqual(currentOutputBpm, targetBpm))
+                {
+                    output.Add(TimingPoint.TimingChange(time, targetBpm));
+                    currentOutputBpm = targetBpm;
+                    hasOutputTimingPoint = true;
+                }
+
+                output.Add(TimingPoint.SliderVelocity(time, targetSliderVelocity));
+            }
+
+            return output;
+        }
+
+        private static (double Bpm, double SliderVelocity) GetOutputTiming(float bpm, float sliderVelocity)
+        {
+            if (bpm <= 0 || sliderVelocity <= 0)
+                return (bpm, MinOsuSliderVelocity);
+
+            if (sliderVelocity < MinOsuSliderVelocity)
+                return (bpm * sliderVelocity / MinOsuSliderVelocity, MinOsuSliderVelocity);
+
+            if (sliderVelocity > MaxOsuSliderVelocity)
+                return (bpm * sliderVelocity / MaxOsuSliderVelocity, MaxOsuSliderVelocity);
+
+            return (bpm, sliderVelocity);
+        }
+
+        private static bool NearlyEqual(double x, double y) => Math.Abs(x - y) < FloatTolerance;
     }
 }

--- a/qua3osu/Osu/TimingPoint.cs
+++ b/qua3osu/Osu/TimingPoint.cs
@@ -13,6 +13,11 @@ namespace qua3osu.Osu
         public int Uninherited = 0;
         public int Kiai = 0;
 
+        private TimingPoint()
+        {
+            
+        }
+
         public TimingPoint(TimingPointInfo timingPoint)
         {
             Time = timingPoint.StartTime;
@@ -23,13 +28,31 @@ namespace qua3osu.Osu
 
         public TimingPoint(SliderVelocityInfo scrollVelocity)
         {
-            Time = scrollVelocity.StartTime;
+            SetSliderVelocity(scrollVelocity.StartTime, scrollVelocity.Multiplier);
+        }
+
+        public static TimingPoint TimingChange(float time, double bpm)
+        {
+            var timingPoint = new TimingPoint { Time = time, Uninherited = 1 };
+            // osu! can't handle 0 BPM, so it's replaced with a very low BPM value instead (0.000006 BPM).
+            timingPoint.BeatLength = bpm <= 0 ? 10e10 : 60000 / bpm;
+            return timingPoint;
+        }
+
+        public static TimingPoint SliderVelocity(float time, double multiplier)
+        {
+            var timingPoint = new TimingPoint();
+            timingPoint.SetSliderVelocity(time, multiplier);
+            return timingPoint;
+        }
+
+        private void SetSliderVelocity(float time, double multiplier)
+        {
+            Time = time;
             Uninherited = 0;
             Meter = 0;
-            // osu! can't handle 0x SV, so it's replaced with a very low value instead (0.00000001x)
-            // It clamps all SV values between 0.01x and 10x, so putting -10e10 instead of -10e4 doesn't really
-            // make a difference. It could change with Lazer though, so it's kept in.
-            BeatLength = scrollVelocity.Multiplier <= 0 ? -10e10 : -100 / scrollVelocity.Multiplier;
+            // osu! clamps inherited timing point multipliers between 0.01x and 10x.
+            BeatLength = multiplier <= 0 ? -10000 : -100 / multiplier;
         }
 
         public override string ToString() =>

--- a/qua3osu/Osu/TimingPoint.cs
+++ b/qua3osu/Osu/TimingPoint.cs
@@ -4,7 +4,7 @@ namespace qua3osu.Osu
 {
     public class TimingPoint
     {
-        public int Time = 0;
+        public float Time = 0;
         public double BeatLength = 0;
         public int Meter = 4;
         public int SampleSet = 0;
@@ -15,7 +15,7 @@ namespace qua3osu.Osu
 
         public TimingPoint(TimingPointInfo timingPoint)
         {
-            Time = (int)Math.Round(timingPoint.StartTime);
+            Time = timingPoint.StartTime;
             Uninherited = 1;
             // osu! can't handle 0 BPM, so it's replaced with a very low BPM value instead (0.000006 BPM).
             BeatLength = timingPoint.Bpm <= 0 ? 10e10 : timingPoint.MillisecondsPerBeat;
@@ -23,7 +23,7 @@ namespace qua3osu.Osu
 
         public TimingPoint(SliderVelocityInfo scrollVelocity)
         {
-            Time = (int)Math.Round(scrollVelocity.StartTime);
+            Time = scrollVelocity.StartTime;
             Uninherited = 0;
             Meter = 0;
             // osu! can't handle 0x SV, so it's replaced with a very low value instead (0.00000001x)

--- a/qua3osu/Osu/TimingPoint.cs
+++ b/qua3osu/Osu/TimingPoint.cs
@@ -11,7 +11,10 @@ namespace qua3osu.Osu
         public int SampleIndex = 0;
         public int Volume = 20;
         public int Uninherited = 0;
-        public int Kiai = 0;
+        public int BitFlag = 0;
+
+        public const int Kiai = 1;
+        public const int OmitFirstBarline = 8;
 
         private TimingPoint()
         {
@@ -31,11 +34,15 @@ namespace qua3osu.Osu
             SetSliderVelocity(scrollVelocity.StartTime, scrollVelocity.Multiplier);
         }
 
-        public static TimingPoint TimingChange(float time, double bpm)
+        public static TimingPoint TimingChange(float time, double bpm, bool omitFirstBarline)
         {
             var timingPoint = new TimingPoint { Time = time, Uninherited = 1 };
             // osu! can't handle 0 BPM, so it's replaced with a very low BPM value instead (0.000006 BPM).
             timingPoint.BeatLength = bpm <= 0 ? 10e10 : 60000 / bpm;
+            if (omitFirstBarline)
+            {
+                timingPoint.BitFlag = OmitFirstBarline;
+            }
             return timingPoint;
         }
 
@@ -56,6 +63,6 @@ namespace qua3osu.Osu
         }
 
         public override string ToString() =>
-            $"{Time},{BeatLength},{Meter},{SampleSet},{SampleIndex},{Volume},{Uninherited},{Kiai}";
+            $"{Time},{BeatLength},{Meter},{SampleSet},{SampleIndex},{Volume},{Uninherited},{BitFlag}";
     }
 }


### PR DESCRIPTION
These changes are done primarily from Codex. I merely added a private constructor for fixing the compile error.

This PR changes timing point generation such that, when encountering SV out of range 0.01-10x, additionally places a BPM change point that shifts the SV into that range. This is used to port my SV map to osu and turned out well for pseudo-teleportation maps, given the TP happens in 1ms not less.